### PR TITLE
Format all files with 'astyle'

### DIFF
--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -11,14 +11,12 @@ char * get_property_value (char * __prop)
 {
     if(__prop == NULL)
     {
-        // make sure the calling programs checks this value
-
 #ifdef DEBUG
         char logstr_debug[BUFSIZ];
         sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]__prop string is NULL");
         log_string (logstr_debug);
 #endif //DEBUG
-
+        // make sure the calling programs checks this value
         return NULL;
     }
     strtok (__prop, "=");
@@ -36,6 +34,18 @@ void set_default_property_value (int what)
         _config[CONFIG_MAX_CONNECTIONS].config_values = (int*) 5;
     else if (what == CONFIG_MAX_AUTHENTICATION_TRIES)
         _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = (int*) 3;
+    else
+    {
+#ifdef DEBUG
+        char logstr_debug[BUFSIZ];
+        sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]what value is not one of the
+                predefined values, setting CONFIG_ALL");
+        log_string (logstr_debug);
+#endif //DEBUG
+        // this is the equivalent of what == CONFIG_ALL
+        _config[CONFIG_MAX_CONNECTIONS].config_values = (int*) 3;
+        _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = (int*) 5;
+    }
 }
 
 int set_property_value (void)

--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -7,77 +7,84 @@
 
 struct config _config[NCONFIG_PROPERTIES]; //access data through this struct
 
-char * get_property_value(char * __prop)
+char * get_property_value (char * __prop)
 {
-        strtok(__prop,"=");
-        return strtok(NULL,"=");
+    strtok (__prop, "=");
+    return strtok (NULL, "=");
 }
 
-void set_default_property_value(int what)
+void set_default_property_value (int what)
 {
-        if (what == CONFIG_ALL) {
-                _config[CONFIG_MAX_CONNECTIONS].config_values=(int*)3;
-                _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values=(int*)5;
-        }
-        else if (what == CONFIG_MAX_CONNECTIONS)
-                _config[CONFIG_MAX_CONNECTIONS].config_values=(int*)5;
-        else if (what == CONFIG_MAX_AUTHENTICATION_TRIES)
-                _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values=(int*)3;
+    if (what == CONFIG_ALL)
+    {
+        _config[CONFIG_MAX_CONNECTIONS].config_values = (int*) 3;
+        _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = (int*) 5;
+    }
+    else if (what == CONFIG_MAX_CONNECTIONS)
+        _config[CONFIG_MAX_CONNECTIONS].config_values = (int*) 5;
+    else if (what == CONFIG_MAX_AUTHENTICATION_TRIES)
+        _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = (int*) 3;
 }
 
-int set_property_value(void)
+int set_property_value (void)
 {
-        #ifdef CONFIGFILE
-        //use it
-        #else
-        char CONFIGFILE[BUFSIZ];
-        strcpy(CONFIGFILE,getenv("HOME"));
-        strcat(CONFIGFILE,"/.jasm_config");
-        #endif
+#ifdef CONFIGFILE
+    //use it
+#else
+    char CONFIGFILE[BUFSIZ];
+    strcpy (CONFIGFILE, getenv ("HOME") );
+    strcat (CONFIGFILE, "/.jasm_config");
+#endif
 
-        FILE * fconfig;
-        char get_buffer_from_file[BUFSIZ];
-        int index;
-        //long test_fsz;
+    FILE * fconfig;
+    char get_buffer_from_file[BUFSIZ];
+    int index;
+    //long test_fsz;
 
-        _config[CONFIG_MAX_CONNECTIONS].config_name="MaxConnections";
-        _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_name="MaxAuthTries";
+    _config[CONFIG_MAX_CONNECTIONS].config_name = "MaxConnections";
+    _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_name = "MaxAuthTries";
 
-        if((fconfig=fopen(CONFIGFILE,"r"))==NULL) {
-                set_default_property_value(CONFIG_ALL);
-                return 1;
+    if ( (fconfig = fopen (CONFIGFILE, "r") ) == NULL)
+    {
+        set_default_property_value (CONFIG_ALL);
+        return 1;
+    }
+
+    for (index = 0; index <= NCONFIG_PROPERTIES; index++)
+    {
+        char * get_val;
+        if (fgets (get_buffer_from_file, BUFSIZ, fconfig) != NULL)
+        {
+#ifdef DEBUG
+            char logstr_debug[BUFSIZ];
+            sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]Buffer: get_buffer_from_file=%s", get_buffer_from_file);
+            log_string (logstr_debug);
+#endif //DEBUG
+
+            get_val = get_property_value (get_buffer_from_file);
+
+#ifdef DEBUG
+            sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]Buffer: %s ,Prop: %s", get_buffer_from_file, get_val);
+            log_string (logstr_debug);
+#endif //DEBUG
+
+            if (strcmp (get_buffer_from_file, "MaxAuthTries") == 0)
+            {
+                int auth_cast_integer_value = atoi (get_val);
+                _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = &auth_cast_integer_value;
+            }
+
+            if (strcmp (get_buffer_from_file, "MaxConnections") == 0)
+            {
+                int conn_cast_integer_value = atoi (get_val);
+                _config[CONFIG_MAX_CONNECTIONS].config_values = &conn_cast_integer_value;
+            }
+
         }
+        else log_string ("[JASM-DAEMON][CONFIG]Configuration file END!");
+    }
 
-        for(index=0; index<=NCONFIG_PROPERTIES; index++) {
-                char * get_val;
-                if(fgets(get_buffer_from_file,BUFSIZ,fconfig)!=NULL) {
-            #ifdef DEBUG
-                        char logstr_debug[BUFSIZ];
-                        sprintf(logstr_debug,"[JASM-DAEMON][DEBUG]Buffer: get_buffer_from_file=%s",get_buffer_from_file);
-                        log_string(logstr_debug);
-            #endif //DEBUG
+    fclose (fconfig);
 
-                        get_val = get_property_value(get_buffer_from_file);
-
-            #ifdef DEBUG
-                        sprintf(logstr_debug,"[JASM-DAEMON][DEBUG]Buffer: %s ,Prop: %s",get_buffer_from_file,get_val);
-                        log_string(logstr_debug);
-            #endif //DEBUG
-
-                        if(strcmp(get_buffer_from_file,"MaxAuthTries")==0) {
-                                int auth_cast_integer_value=atoi(get_val);
-                                _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values=&auth_cast_integer_value;
-                        }
-
-                        if(strcmp(get_buffer_from_file,"MaxConnections")==0) {
-                                int conn_cast_integer_value=atoi(get_val);
-                                _config[CONFIG_MAX_CONNECTIONS].config_values=&conn_cast_integer_value;
-                        }
-
-                } else log_string("[JASM-DAEMON][CONFIG]Configuration file END!");
-        }
-
-        fclose(fconfig);
-
-        return 0;
+    return 0;
 }

--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -9,7 +9,7 @@ struct config _config[NCONFIG_PROPERTIES]; //access data through this struct
 
 char * get_property_value (char * __prop)
 {
-    if (__prop == NULL)
+    if(__prop == NULL)
     {
 #ifdef DEBUG
         char logstr_debug[BUFSIZ];
@@ -54,7 +54,7 @@ int set_property_value (void)
 #else
     char CONFIGFILE[BUFSIZ];
     // use the bounded version now
-    strncpy (CONFIGFILE, getenv ("HOME"), strlen (getenv ("HOME") ) );
+    strncpy (CONFIGFILE, getenv ("HOME"), strlen(getenv("HOME")));
     strcat (CONFIGFILE, "/.jasm_config");
 #endif
 
@@ -85,7 +85,7 @@ int set_property_value (void)
 
             get_val = get_property_value (get_buffer_from_file);
 
-            if (get_val == NULL)
+            if(get_val == NULL)
             {
 #ifdef DEBUG
                 sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]get_val is NULL. config set to CONFIG_ALL");
@@ -102,14 +102,14 @@ int set_property_value (void)
 #endif //DEBUG
 
             // add bounded check for string comparison, to prevent buffer overflow
-            if (strncmp (get_buffer_from_file, "MaxAuthTries", strlen (get_buffer_from_file) ) == 0)
+            if (strncmp (get_buffer_from_file, "MaxAuthTries", strlen(get_buffer_from_file)) == 0)
             {
                 // make a promise to change atoi to strtol to ease the error checking phase
                 int auth_cast_integer_value = atoi (get_val);
                 _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = &auth_cast_integer_value;
             }
             // add bounded check for string comparison, to prevent buffer overflow
-            if (strncmp (get_buffer_from_file, "MaxConnections", strlen (get_buffer_from_file) ) == 0)
+            if (strncmp (get_buffer_from_file, "MaxConnections", strlen(get_buffer_from_file)) == 0)
             {
                 int conn_cast_integer_value = atoi (get_val);
                 _config[CONFIG_MAX_CONNECTIONS].config_values = &conn_cast_integer_value;

--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -38,8 +38,7 @@ void set_default_property_value (int what)
     {
 #ifdef DEBUG
         char logstr_debug[BUFSIZ];
-        sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]what value is not one of the
-                predefined values, setting CONFIG_ALL");
+        sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]what value is not one of the predefined values, setting CONFIG_ALL");
         log_string (logstr_debug);
 #endif //DEBUG
         // this is the equivalent of what == CONFIG_ALL
@@ -54,11 +53,11 @@ int set_property_value (void)
     //use it
 #else
     char CONFIGFILE[BUFSIZ];
-    strcpy (CONFIGFILE, getenv ("HOME") );
+    strncpy (CONFIGFILE, getenv ("HOME"), strlen(getenv("HOME")));
     strcat (CONFIGFILE, "/.jasm_config");
 #endif
 
-    FILE * fconfig;
+    FILE *fconfig;
     char get_buffer_from_file[BUFSIZ];
     int index;
     //long test_fsz;
@@ -74,7 +73,7 @@ int set_property_value (void)
 
     for (index = 0; index <= NCONFIG_PROPERTIES; index++)
     {
-        char * get_val;
+        char *get_val;
         if (fgets (get_buffer_from_file, BUFSIZ, fconfig) != NULL)
         {
 #ifdef DEBUG
@@ -89,8 +88,8 @@ int set_property_value (void)
             sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]Buffer: %s ,Prop: %s", get_buffer_from_file, get_val);
             log_string (logstr_debug);
 #endif //DEBUG
-
-            if (strcmp (get_buffer_from_file, "MaxAuthTries") == 0)
+            // add bounded check for string comparison, to prevent buffer overflow
+            if (strncmp (get_buffer_from_file, "MaxAuthTries", strlen(get_buffer_from_file)) == 0)
             {
                 int auth_cast_integer_value = atoi (get_val);
                 _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = &auth_cast_integer_value;

--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -9,6 +9,18 @@ struct config _config[NCONFIG_PROPERTIES]; //access data through this struct
 
 char * get_property_value (char * __prop)
 {
+    if(__prop == NULL)
+    {
+        // make sure the calling programs checks this value
+
+#ifdef DEBUG
+        char logstr_debug[BUFSIZ];
+        sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]__prop string is NULL");
+        log_string (logstr_debug);
+#endif //DEBUG
+
+        return NULL;
+    }
     strtok (__prop, "=");
     return strtok (NULL, "=");
 }

--- a/src/main/jasm/core/configfile.c
+++ b/src/main/jasm/core/configfile.c
@@ -9,7 +9,7 @@ struct config _config[NCONFIG_PROPERTIES]; //access data through this struct
 
 char * get_property_value (char * __prop)
 {
-    if(__prop == NULL)
+    if (__prop == NULL)
     {
 #ifdef DEBUG
         char logstr_debug[BUFSIZ];
@@ -54,7 +54,7 @@ int set_property_value (void)
 #else
     char CONFIGFILE[BUFSIZ];
     // use the bounded version now
-    strncpy (CONFIGFILE, getenv ("HOME"), strlen(getenv("HOME")));
+    strncpy (CONFIGFILE, getenv ("HOME"), strlen (getenv ("HOME") ) );
     strcat (CONFIGFILE, "/.jasm_config");
 #endif
 
@@ -85,7 +85,7 @@ int set_property_value (void)
 
             get_val = get_property_value (get_buffer_from_file);
 
-            if(get_val == NULL)
+            if (get_val == NULL)
             {
 #ifdef DEBUG
                 sprintf (logstr_debug, "[JASM-DAEMON][DEBUG]get_val is NULL. config set to CONFIG_ALL");
@@ -102,14 +102,14 @@ int set_property_value (void)
 #endif //DEBUG
 
             // add bounded check for string comparison, to prevent buffer overflow
-            if (strncmp (get_buffer_from_file, "MaxAuthTries", strlen(get_buffer_from_file)) == 0)
+            if (strncmp (get_buffer_from_file, "MaxAuthTries", strlen (get_buffer_from_file) ) == 0)
             {
                 // make a promise to change atoi to strtol to ease the error checking phase
                 int auth_cast_integer_value = atoi (get_val);
                 _config[CONFIG_MAX_AUTHENTICATION_TRIES].config_values = &auth_cast_integer_value;
             }
             // add bounded check for string comparison, to prevent buffer overflow
-            if (strncmp (get_buffer_from_file, "MaxConnections", strlen(get_buffer_from_file)) == 0)
+            if (strncmp (get_buffer_from_file, "MaxConnections", strlen (get_buffer_from_file) ) == 0)
             {
                 int conn_cast_integer_value = atoi (get_val);
                 _config[CONFIG_MAX_CONNECTIONS].config_values = &conn_cast_integer_value;

--- a/src/main/jasm/core/configfile.h
+++ b/src/main/jasm/core/configfile.h
@@ -7,11 +7,12 @@
 #define CONFIG_MAX_CONNECTIONS 0
 #define CONFIG_ALL -1
 
-extern struct config {
-        char * config_name;
-        void * config_values;
+extern struct config
+{
+    char * config_name;
+    void * config_values;
 } _config[NCONFIG_PROPERTIES];
 
-extern int set_property_value(void);
+extern int set_property_value (void);
 
 #endif // CONFIGFILE_H

--- a/src/main/jasm/core/getter.c
+++ b/src/main/jasm/core/getter.c
@@ -31,211 +31,271 @@ char error[BUFSIZ];
 
 //TODO: checks + errno
 
-void getVersion(int fd);
-void getCopyright(int fd);
-void getHostname(int fd);
-void getKernelName(int fd);
-void getKernelRelease(int fd);
-void getKernelVersion(int fd);
-void getMachine(int fd);
-void getGetter(int fd);
+void getVersion (int fd);
+void getCopyright (int fd);
+void getHostname (int fd);
+void getKernelName (int fd);
+void getKernelRelease (int fd);
+void getKernelVersion (int fd);
+void getMachine (int fd);
+void getGetter (int fd);
 
-char getterName[NGETTER][BUFSIZ]={"Version", "Copyright", "Hostname", "KernelName",
-                                  "KernelRelease", "KernelVersion", "Machine"};
+char getterName[NGETTER][BUFSIZ] = {"Version", "Copyright", "Hostname", "KernelName",
+                                    "KernelRelease", "KernelVersion", "Machine"
+                                   };
 
-void (*getterFunction[NGETTER])(int)={getVersion, getCopyright, getHostname,
-                                      getKernelName, getKernelRelease, getKernelVersion, getMachine};
+void (*getterFunction[NGETTER]) (int) = {getVersion, getCopyright, getHostname,
+                                         getKernelName, getKernelRelease, getKernelVersion, getMachine
+                                        };
 
 /*
  *  scrive su fd int numero getter e N stringhe nomiGetter
  */
-void getGetter(int fd)
+void getGetter (int fd)
 {
-        int i;
-        int ngetter = NGETTER;
-        int count=0;
+    int i;
+    int ngetter = NGETTER;
+    int count = 0;
 
-        write(fd, &ngetter, sizeof(ngetter));
+    write (fd, &ngetter, sizeof (ngetter) );
 
-        for(i=0; i<NGETTER; i++) {
-                count = strlen(getterName[i]);
-                //aggiungere check errore nell'invio
-                write(fd, &count, sizeof(count));
-                write(fd, getterName[i], strlen(getterName[i]));
-        }
+    for (i = 0; i < NGETTER; i++)
+    {
+        count = strlen (getterName[i]);
+        //aggiungere check errore nell'invio
+        write (fd, &count, sizeof (count) );
+        write (fd, getterName[i], strlen (getterName[i]) );
+    }
 }
 
-void getVersion(int fd)
+void getVersion (int fd)
 {
-        int n;
+    int n;
 
-        n = write(fd, VERSION, strlen(VERSION));
-        if(n < 0) {
-                sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                log_error("[JASM-DAEMON][getVersion][write()] Error!");
-                log_error(error);
-        } else {
-                if(n < strlen(VERSION)) {
-                        sprintf(error, "[JASM-DAEMON][getVersion][write()] sent %d byte, correct num byte is %zu", n, strlen(VERSION));
-                        log_error(error);
-                } else {
-                        sprintf(error, "[JASM-DAEMON][getVersion][write()] sent %d byte", n);
-                        log_string(error);
-                }
+    n = write (fd, VERSION, strlen (VERSION) );
+    if (n < 0)
+    {
+        sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+        log_error ("[JASM-DAEMON][getVersion][write()] Error!");
+        log_error (error);
+    }
+    else
+    {
+        if (n < strlen (VERSION) )
+        {
+            sprintf (error, "[JASM-DAEMON][getVersion][write()] sent %d byte, correct num byte is %zu", n, strlen (VERSION) );
+            log_error (error);
         }
+        else
+        {
+            sprintf (error, "[JASM-DAEMON][getVersion][write()] sent %d byte", n);
+            log_string (error);
+        }
+    }
 }
 
-void getCopyright(int fd)
+void getCopyright (int fd)
 {
-        int n;
+    int n;
 
-        n = write(fd, COPYRIGHT, strlen(COPYRIGHT));
-        if(n < 0) {
-                sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                log_error("[JASM-DAEMON][getCopyright][write()] Error!");
-                log_error(error);
-        } else {
-                if(n < strlen(COPYRIGHT)) {
-                        sprintf(error, "[JASM-DAEMON][getCopyright][write()] sent %d byte, correct num byte is %zu", n, strlen(COPYRIGHT));
-                        log_error(error);
-                } else {
-                        sprintf(error, "[JASM-DAEMON][getCopyright][write()] sent %d byte", n);
-                        log_string(error);
-                }
+    n = write (fd, COPYRIGHT, strlen (COPYRIGHT) );
+    if (n < 0)
+    {
+        sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+        log_error ("[JASM-DAEMON][getCopyright][write()] Error!");
+        log_error (error);
+    }
+    else
+    {
+        if (n < strlen (COPYRIGHT) )
+        {
+            sprintf (error, "[JASM-DAEMON][getCopyright][write()] sent %d byte, correct num byte is %zu", n, strlen (COPYRIGHT) );
+            log_error (error);
         }
+        else
+        {
+            sprintf (error, "[JASM-DAEMON][getCopyright][write()] sent %d byte", n);
+            log_string (error);
+        }
+    }
 }
 
-void getHostname(int fd)
+void getHostname (int fd)
 {
-        struct utsname info;
-        char buf[BUFSIZ];
+    struct utsname info;
+    char buf[BUFSIZ];
 
-        if(uname(&info)==-1) {
-                log_error("getHostname() [uname] failed");
-                return;
-        } else {
-                strcpy(buf, info.nodename);
-                int n = write(fd, buf, strlen(buf));
-                if(n < 0) {
-                        sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                        log_error("[JASM-DAEMON][getHostname][write()] Error!");
-                        log_error(error);
-                } else {
-                        if(n < strlen(buf)) {
-                                sprintf(error, "[JASM-DAEMON][getHostname][write()] sent %d byte, correct num byte is %zu", n, strlen(buf));
-                                log_error(error);
-                        } else {
-                                sprintf(error, "[JASM-DAEMON][getHostname][write()] sent %d byte", n);
-                                log_string(error);
-                        }
-                }
+    if (uname (&info) == -1)
+    {
+        log_error ("getHostname() [uname] failed");
+        return;
+    }
+    else
+    {
+        strcpy (buf, info.nodename);
+        int n = write (fd, buf, strlen (buf) );
+        if (n < 0)
+        {
+            sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+            log_error ("[JASM-DAEMON][getHostname][write()] Error!");
+            log_error (error);
         }
+        else
+        {
+            if (n < strlen (buf) )
+            {
+                sprintf (error, "[JASM-DAEMON][getHostname][write()] sent %d byte, correct num byte is %zu", n, strlen (buf) );
+                log_error (error);
+            }
+            else
+            {
+                sprintf (error, "[JASM-DAEMON][getHostname][write()] sent %d byte", n);
+                log_string (error);
+            }
+        }
+    }
 }
 
-void getKernelName(int fd)
+void getKernelName (int fd)
 {
-        struct utsname info;
-        char buf[BUFSIZ];
+    struct utsname info;
+    char buf[BUFSIZ];
 
-        if(uname(&info)==-1) {
-                log_error("getKernelName() [uname] failed");
-                return;
-        } else {
-                strcpy(buf, info.sysname);
-                int n = write(fd, buf, strlen(buf));
-                if(n < 0) {
-                        sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                        log_error("[JASM-DAEMON][getKernelName][write()] Error!");
-                        log_error(error);
-                } else {
-                        if(n < strlen(buf)) {
-                                sprintf(error, "[JASM-DAEMON][getKernelName][write()] sent %d byte, correct num byte is %zu", n, strlen(buf));
-                                log_error(error);
-                        } else {
-                                sprintf(error, "[JASM-DAEMON][getKernelName][write()] sent %d byte", n);
-                                log_string(error);
-                        }
-                }
+    if (uname (&info) == -1)
+    {
+        log_error ("getKernelName() [uname] failed");
+        return;
+    }
+    else
+    {
+        strcpy (buf, info.sysname);
+        int n = write (fd, buf, strlen (buf) );
+        if (n < 0)
+        {
+            sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+            log_error ("[JASM-DAEMON][getKernelName][write()] Error!");
+            log_error (error);
         }
+        else
+        {
+            if (n < strlen (buf) )
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelName][write()] sent %d byte, correct num byte is %zu", n, strlen (buf) );
+                log_error (error);
+            }
+            else
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelName][write()] sent %d byte", n);
+                log_string (error);
+            }
+        }
+    }
 }
 
-void getKernelRelease(int fd)
+void getKernelRelease (int fd)
 {
-        struct utsname info;
-        char buf[BUFSIZ];
+    struct utsname info;
+    char buf[BUFSIZ];
 
-        if(uname(&info)==-1) {
-                log_error("getKernelRelease() [uname] failed");
-                return;
-        } else {
-                strcpy(buf, info.release);
-                int n = write(fd, buf, strlen(buf));
-                if(n < 0) {
-                        sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                        log_error("[JASM-DAEMON][getKernelRelease][write()] Error!");
-                        log_error(error);
-                } else {
-                        if(n < strlen(buf)) {
-                                sprintf(error, "[JASM-DAEMON][getKernelRelease][write()] sent %d byte, correct num byte is %zu", n, strlen(buf));
-                                log_error(error);
-                        } else {
-                                sprintf(error, "[JASM-DAEMON][getKernelRelease][write()] sent %d byte", n);
-                                log_string(error);
-                        }
-                }
+    if (uname (&info) == -1)
+    {
+        log_error ("getKernelRelease() [uname] failed");
+        return;
+    }
+    else
+    {
+        strcpy (buf, info.release);
+        int n = write (fd, buf, strlen (buf) );
+        if (n < 0)
+        {
+            sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+            log_error ("[JASM-DAEMON][getKernelRelease][write()] Error!");
+            log_error (error);
         }
+        else
+        {
+            if (n < strlen (buf) )
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelRelease][write()] sent %d byte, correct num byte is %zu", n, strlen (buf) );
+                log_error (error);
+            }
+            else
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelRelease][write()] sent %d byte", n);
+                log_string (error);
+            }
+        }
+    }
 }
 
-void getKernelVersion(int fd)
+void getKernelVersion (int fd)
 {
-        struct utsname info;
-        char buf[BUFSIZ];
+    struct utsname info;
+    char buf[BUFSIZ];
 
-        if(uname(&info)==-1) {
-                log_error("getKernelVersion() [uname] failed");
-                return;
-        } else {
-                strcpy(buf, info.version);
-                int n = write(fd, buf, strlen(buf));
-                if(n < 0) {
-                        sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                        log_error("[JASM-DAEMON][getKernelVersion][write()] Error!");
-                        log_error(error);
-                } else {
-                        if(n < strlen(buf)) {
-                                sprintf(error, "[JASM-DAEMON][getKernelVersion][write()] sent %d byte, correct num byte is %zu", n, strlen(buf));
-                                log_error(error);
-                        } else {
-                                sprintf(error, "[JASM-DAEMON][getKernelVersion][write()] sent %d byte", n);
-                                log_string(error);
-                        }
-                }
+    if (uname (&info) == -1)
+    {
+        log_error ("getKernelVersion() [uname] failed");
+        return;
+    }
+    else
+    {
+        strcpy (buf, info.version);
+        int n = write (fd, buf, strlen (buf) );
+        if (n < 0)
+        {
+            sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+            log_error ("[JASM-DAEMON][getKernelVersion][write()] Error!");
+            log_error (error);
         }
+        else
+        {
+            if (n < strlen (buf) )
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelVersion][write()] sent %d byte, correct num byte is %zu", n, strlen (buf) );
+                log_error (error);
+            }
+            else
+            {
+                sprintf (error, "[JASM-DAEMON][getKernelVersion][write()] sent %d byte", n);
+                log_string (error);
+            }
+        }
+    }
 }
 
-void getMachine(int fd)
+void getMachine (int fd)
 {
-        struct utsname info;
-        char buf[BUFSIZ];
+    struct utsname info;
+    char buf[BUFSIZ];
 
-        if(uname(&info)==-1) {
-                log_error("getMachine() [uname]  failed");
-                return;
-        } else {
-                strcpy(buf, info.machine);
-                int n = write(fd, buf, strlen(buf));
-                if(n < 0) {
-                        sprintf(error, "[JASM-DAEMON][errno] %s", strerror(errno));
-                        log_error("[JASM-DAEMON][getMachine][write()] Error!");
-                        log_error(error);
-                } else {
-                        if(n < strlen(buf)) {
-                                sprintf(error, "[JASM-DAEMON][getMachine][write()] sent %d byte, correct num byte is %zu", n, strlen(buf));
-                                log_error(error);
-                        } else {
-                                sprintf(error, "[JASM-DAEMON][getMachine][write()] sent %d byte", n);
-                                log_string(error);
-                        }
-                }
+    if (uname (&info) == -1)
+    {
+        log_error ("getMachine() [uname]  failed");
+        return;
+    }
+    else
+    {
+        strcpy (buf, info.machine);
+        int n = write (fd, buf, strlen (buf) );
+        if (n < 0)
+        {
+            sprintf (error, "[JASM-DAEMON][errno] %s", strerror (errno) );
+            log_error ("[JASM-DAEMON][getMachine][write()] Error!");
+            log_error (error);
         }
+        else
+        {
+            if (n < strlen (buf) )
+            {
+                sprintf (error, "[JASM-DAEMON][getMachine][write()] sent %d byte, correct num byte is %zu", n, strlen (buf) );
+                log_error (error);
+            }
+            else
+            {
+                sprintf (error, "[JASM-DAEMON][getMachine][write()] sent %d byte", n);
+                log_string (error);
+            }
+        }
+    }
 }

--- a/src/main/jasm/core/getter.c
+++ b/src/main/jasm/core/getter.c
@@ -54,17 +54,36 @@ void (*getterFunction[NGETTER]) (int) = {getVersion, getCopyright, getHostname,
 void getGetter (int fd)
 {
     int i;
-    int ngetter = NGETTER;
+    int n_getter = NGETTER;
     int count = 0;
+    //start from an error condition, to make sure we do not miss anything
+    ssize_t ret_val = -1;
 
-    write (fd, &ngetter, sizeof (ngetter) );
+    ret_val = write (fd, &n_getter, sizeof (n_getter) );
+
+    if(ret_val == 0 || ret_val == -1)
+    {
+        log_error ("[JASM-DAEMON][getGetter][write()] Error! ret_val is 0 or -1");
+        log_error (error);
+    }
 
     for (i = 0; i < NGETTER; i++)
     {
         count = strlen (getterName[i]);
-        //aggiungere check errore nell'invio
-        write (fd, &count, sizeof (count) );
-        write (fd, getterName[i], strlen (getterName[i]) );
+        ret_val = write (fd, &count, sizeof (count) );
+
+        if(ret_val == 0 || ret_val == -1)
+        {
+            log_error ("[JASM-DAEMON][getGetter][write()] Error! ret_val is 0 or -1");
+            log_error (error);
+        }
+        ret_val = write (fd, getterName[i], strlen (getterName[i]) );
+
+        if(ret_val == 0 || ret_val == -1)
+        {
+            log_error ("[JASM-DAEMON][getGetter][write()] Error! ret_val is 0 or -1");
+            log_error (error);
+        }
     }
 }
 

--- a/src/main/jasm/core/getter.c
+++ b/src/main/jasm/core/getter.c
@@ -40,27 +40,26 @@ void getKernelVersion (int fd);
 void getMachine (int fd);
 void getGetter (int fd);
 
-char getterName[n_getter][BUFSIZ] = {"Version", "Copyright", "Hostname", "KernelName",
+char getterName[NGETTER][BUFSIZ] = {"Version", "Copyright", "Hostname", "KernelName",
                                     "KernelRelease", "KernelVersion", "Machine"
                                    };
 
-void (*getterFunction[n_getter]) (int) = {getVersion, getCopyright, getHostname,
+void (*getterFunction[NGETTER]) (int) = {getVersion, getCopyright, getHostname,
                                          getKernelName, getKernelRelease, getKernelVersion, getMachine
                                         };
 
 /*
  *  scrive su fd int numero getter e N stringhe nomiGetter
- *  write on fd an integer, then read N strings as getter names
  */
 void getGetter (int fd)
 {
-    int i = 0;
-    int n_getter = n_getter;
+    int i;
+    int ngetter = NGETTER;
     int count = 0;
 
-    write (fd, &n_getter, sizeof (n_getter) );
+    write (fd, &ngetter, sizeof (ngetter) );
 
-    for (i = 0; i < n_getter; i++)
+    for (i = 0; i < NGETTER; i++)
     {
         count = strlen (getterName[i]);
         //aggiungere check errore nell'invio

--- a/src/main/jasm/core/getter.c
+++ b/src/main/jasm/core/getter.c
@@ -40,26 +40,27 @@ void getKernelVersion (int fd);
 void getMachine (int fd);
 void getGetter (int fd);
 
-char getterName[NGETTER][BUFSIZ] = {"Version", "Copyright", "Hostname", "KernelName",
+char getterName[n_getter][BUFSIZ] = {"Version", "Copyright", "Hostname", "KernelName",
                                     "KernelRelease", "KernelVersion", "Machine"
                                    };
 
-void (*getterFunction[NGETTER]) (int) = {getVersion, getCopyright, getHostname,
+void (*getterFunction[n_getter]) (int) = {getVersion, getCopyright, getHostname,
                                          getKernelName, getKernelRelease, getKernelVersion, getMachine
                                         };
 
 /*
  *  scrive su fd int numero getter e N stringhe nomiGetter
+ *  write on fd an integer, then read N strings as getter names
  */
 void getGetter (int fd)
 {
-    int i;
-    int ngetter = NGETTER;
+    int i = 0;
+    int n_getter = n_getter;
     int count = 0;
 
-    write (fd, &ngetter, sizeof (ngetter) );
+    write (fd, &n_getter, sizeof (n_getter) );
 
-    for (i = 0; i < NGETTER; i++)
+    for (i = 0; i < n_getter; i++)
     {
         count = strlen (getterName[i]);
         //aggiungere check errore nell'invio

--- a/src/main/jasm/core/getter.h
+++ b/src/main/jasm/core/getter.h
@@ -22,15 +22,15 @@
 #define NGETTER 7
 
 extern char getterName[NGETTER][BUFSIZ];
-extern void (*getterFunction[NGETTER])(int);
+extern void (*getterFunction[NGETTER]) (int);
 
-extern void getVersion(int fd); //return jasm version
-extern void getCopyright(int fd); //return copyng license
-extern void getHostname(int fd);
-extern void getKernelName(int fd);
-extern void getKernelRelease(int fd);
-extern void getKernelVersion(int fd);
-extern void getMachine(int fd);
-extern void getGetter(int fd);
+extern void getVersion (int fd); //return jasm version
+extern void getCopyright (int fd); //return copyng license
+extern void getHostname (int fd);
+extern void getKernelName (int fd);
+extern void getKernelRelease (int fd);
+extern void getKernelVersion (int fd);
+extern void getMachine (int fd);
+extern void getGetter (int fd);
 
 #endif

--- a/src/main/jasm/core/ipc.c
+++ b/src/main/jasm/core/ipc.c
@@ -39,392 +39,453 @@ char errlog[BUFSIZ];
 
 //NOTE: Error codes defined @ miscellaneous.h
 
-static void excecute_command(int fd, char *command)
+static void excecute_command (int fd, char *command)
 {
-        //static int module_index = 0;
+    //static int module_index = 0;
 
-        // write on fd a list of commands
-        if(strcmp("help", command)==0) {
+    // write on fd a list of commands
+    if (strcmp ("help", command) == 0)
+    {
 
-                getGetter(fd);
-                getModule(fd);
-                //getOther
+        getGetter (fd);
+        getModule (fd);
+        //getOther
 
-                log_string("[CMD] help exec");
+        log_string ("[CMD] help exec");
+        return;
+    }
+
+    // ************************** getter ***************************************
+    if (strncmp ("get", command, 3) == 0) //if recv get command
+    {
+        int i;
+
+        strcpy (command, &command[3]);
+
+        for (i = 0; i < NGETTER; i++)
+        {
+            if (strcmp (getterName[i], command) == 0) //if getter exists
+            {
+                getterFunction[i] (fd);
                 return;
+            }
         }
 
-        // ************************** getter ***************************************
-        if(strncmp("get", command, 3)==0) { //if recv get command
-                int i;
+        log_error ("Getter NOT found :(");
+        write (fd, "null", strlen ("null") );
+        return;
+    }
 
-                strcpy(command, &command[3]);
+    // ************************** starter **************************************
+    if (strncmp ("start", command, 5) == 0) //recieved start mod
+    {
+        int i; //j;
 
-                for(i=0; i<NGETTER; i++) {
-                        if(strcmp(getterName[i], command)==0) { //if getter exists
-                                getterFunction[i](fd);
-                                return;
-                        }
+        strcpy (command, &command[5]);
+
+        for (i = 0; i < NMODULE; i++)
+        {
+            if (strcmp (moduleName[i], command) == 0)
+            {
+                //module exists :D
+
+                moduleInit[i] (fd, 1); //to fix sec IMPORTANTE@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                pthread_t tid;
+
+                write (fd, "success", strlen ("success") );
+
+                if (pthread_create (&tid, NULL, (void*) moduleStart[i], NULL) != 0)
+                {
+                    char buf[BUFSIZ];
+                    sprintf (buf, "pthread_create fail: %s", strerror (errno) );
+                    log_error (buf);
+                    return;
+
+                }
+                else
+                {
+                    memset (command, 0, BUFSIZ);
+                    sprintf (command, "module <%s> started correctly", moduleName[i]);
+                    log_string (command);
+                    return;
                 }
 
-                log_error("Getter NOT found :(");
-                write(fd, "null", strlen("null"));
-                return;
-        }
+                /*for(j=0; j<NMODULE; j++) {
+                      if(strcmp(module_table[j], command) == 0) {
+                          //if there is the same module in execution
+                          char temp[BUFSIZ];
 
-        // ************************** starter **************************************
-        if(strncmp("start", command, 5)==0) { //recieved start mod
-                int i; //j;
-
-                strcpy(command, &command[5]);
-
-                for(i=0; i<NMODULE; i++) {
-                        if(strcmp(moduleName[i], command)==0) {
-                                //module exists :D
-
-                                moduleInit[i](fd, 1); //to fix sec IMPORTANTE@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-                                pthread_t tid;
-
-                                write(fd, "success", strlen("success"));
-
-                                if(pthread_create(&tid, NULL, (void*)moduleStart[i], NULL) != 0) {
-                                        char buf[BUFSIZ];
-                                        sprintf(buf, "pthread_create fail: %s", strerror(errno));
-                                        log_error(buf);
-                                        return;
-
-                                } else {
-                                        memset(command, 0, BUFSIZ);
-                                        sprintf(command, "module <%s> started correctly", moduleName[i]);
-                                        log_string(command);
-                                        return;
-                                }
-
-                                /*for(j=0; j<NMODULE; j++) {
-                                      if(strcmp(module_table[j], command) == 0) {
-                                          //if there is the same module in execution
-                                          char temp[BUFSIZ];
-
-                                          sprintf(temp, "Module [%s] already is in execution!", command);
-                                          log_error(temp);
-                                          write(fd, temp, strlen(temp));
-                                          return;
-                                        }
-                                   }
-
-                                   //if there isn't the module in execution -> execute and update module_table
-                                   moduleInit[i](fd, 1) //to fix sec IMPORTANTE@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
-                                   pthread_t tid;
-
-                                   if(pthread_create(&tid, NULL, moduleStart[i], NULL) != 0) {
-                                    log_error("pthread_create fail");
-                                    write(fd, "error creating thread", strlen("error creating thread"));
-                                    exit(1);
-                                   }
-                                   module_table[module_index++] = {};*/
+                          sprintf(temp, "Module [%s] already is in execution!", command);
+                          log_error(temp);
+                          write(fd, temp, strlen(temp));
+                          return;
                         }
-                }
+                   }
 
-                log_error("Start NOT found :(");
-                write(fd, "null", strlen("null"));
-                return;
+                   //if there isn't the module in execution -> execute and update module_table
+                   moduleInit[i](fd, 1) //to fix sec IMPORTANTE@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+                   pthread_t tid;
+
+                   if(pthread_create(&tid, NULL, moduleStart[i], NULL) != 0) {
+                    log_error("pthread_create fail");
+                    write(fd, "error creating thread", strlen("error creating thread"));
+                    exit(1);
+                   }
+                   module_table[module_index++] = {};*/
+            }
         }
 
-        // ************************** miscellaneous ********************************
-        if(strcmp("halt", command)==0) { //turn off jasm
-                log_string("[CMD] halt exec");
-                write(fd, "Killing JASM...", strlen("Killing JASM..."));
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_INFO,"exiting as requested from client...");
-                closelog();
-                exit(_EXIT_SUCCESS);
-        }
+        log_error ("Start NOT found :(");
+        write (fd, "null", strlen ("null") );
+        return;
+    }
 
-        log_error("[CMD] Command not found!");
-        write(fd, "NotFound", strlen("NotFound"));
+    // ************************** miscellaneous ********************************
+    if (strcmp ("halt", command) == 0) //turn off jasm
+    {
+        log_string ("[CMD] halt exec");
+        write (fd, "Killing JASM...", strlen ("Killing JASM...") );
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_INFO, "exiting as requested from client...");
+        closelog();
+        exit (_EXIT_SUCCESS);
+    }
+
+    log_error ("[CMD] Command not found!");
+    write (fd, "NotFound", strlen ("NotFound") );
 }
 
 
 void start_server()
 {
-  #ifdef PASSWD_ENC_FILE
-        //use it
-  #else
-        char PASSWD_ENC_FILE[256];
-        strcpy(PASSWD_ENC_FILE, getenv("HOME"));
-        strcat(PASSWD_ENC_FILE, "/.jpwd");
-  #endif
+#ifdef PASSWD_ENC_FILE
+    //use it
+#else
+    char PASSWD_ENC_FILE[256];
+    strcpy (PASSWD_ENC_FILE, getenv ("HOME") );
+    strcat (PASSWD_ENC_FILE, "/.jpwd");
+#endif
 
-  #ifdef CHECK_ACCESS_FILE
-        //use it
-  #else
-        char CHECK_ACCESS_FILE[256];
-        strcpy(CHECK_ACCESS_FILE,getenv("HOME"));
-        strcat(CHECK_ACCESS_FILE,"/.jpwdchk");
-  #endif // CHECK_ACCESS_FILE
+#ifdef CHECK_ACCESS_FILE
+    //use it
+#else
+    char CHECK_ACCESS_FILE[256];
+    strcpy (CHECK_ACCESS_FILE, getenv ("HOME") );
+    strcat (CHECK_ACCESS_FILE, "/.jpwdchk");
+#endif // CHECK_ACCESS_FILE
 
-        int server_sockfd, client_sockfd;
-        int server_len;
-        socklen_t client_len;
-        struct sockaddr_in server_address;
-        struct sockaddr_in client_address;
-        int result;
-        char client_ipaddr[30];
+    int server_sockfd, client_sockfd;
+    int server_len;
+    socklen_t client_len;
+    struct sockaddr_in server_address;
+    struct sockaddr_in client_address;
+    int result;
+    char client_ipaddr[30];
 
-        fd_set readfds, testfds;
+    fd_set readfds, testfds;
 
-        client_sockfd=0;
+    client_sockfd = 0;
 
-        server_sockfd = socket(AF_INET, SOCK_STREAM, 0);
-        if(server_sockfd < 0) {
-                sprintf(errlog, "[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                log_error("[JASM-DAEMON][socket()]Failed to create new socket! Exiting...");
-                log_error(errlog);
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_ERR,"socket creation failed!! Exiting!");
-                closelog();
-                exit(SOCKET_CREATION_FAILED);
+    server_sockfd = socket (AF_INET, SOCK_STREAM, 0);
+    if (server_sockfd < 0)
+    {
+        sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+        log_error ("[JASM-DAEMON][socket()]Failed to create new socket! Exiting...");
+        log_error (errlog);
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_ERR, "socket creation failed!! Exiting!");
+        closelog();
+        exit (SOCKET_CREATION_FAILED);
+    }
+    server_address.sin_family = AF_INET;
+    server_address.sin_addr.s_addr = htonl (INADDR_ANY);
+    server_address.sin_port = htons (SERVER_PORT);
+    server_len = sizeof (server_address);
+
+    if (bind (server_sockfd, (struct sockaddr *) &server_address, server_len) < 0)
+    {
+        sprintf (errlog, "[JASM-DAEMON][bind()]Error: %s\n", strerror (errno) );
+        log_error ("[JASM-DAEMON][bind()]Failed to bind socket");
+        log_error (errlog);
+        log_error ("[JASM-DAEMON] Exiting !");
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_ERR, "socket not correctly binded... exiting!");
+        closelog();
+        exit (SOCKET_BINDING_FAILED);
+    }
+
+    if (listen (server_sockfd, 5) < 0)
+    {
+        sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+        log_error ("[JASM-DAEMON][listen()]Failed to put socket in listening mode!");
+        log_error (errlog);
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_ERR, "FATAL! socket was not put to listening mode! Exiting...");
+        closelog();
+        exit (SOCKET_LISTENING_CONNECTION_FAILED);
+    }
+
+    FD_ZERO (&readfds);
+    FD_SET (server_sockfd, &readfds);
+
+    log_string ("[JASM-DAEMON]Server started");
+
+    while (1)
+    {
+        char buf[BUFSIZ];
+        char received[BUFSIZ];
+        int fd;
+        int nread;
+
+        testfds = readfds;
+
+        result = select (FD_SETSIZE, &testfds, (fd_set *) 0, (fd_set *) 0, (struct timeval *) 0);
+
+        if (result < 1)
+        {
+            sprintf (errlog, "[JASM-DAEMON]Error: %s\n", strerror (errno) );
+            log_error ("[JASM-DAEMON][select()]Server failed");
+            log_error (errlog);
+            exit (SOCKET_SELECT_FAILED);
         }
-        server_address.sin_family=AF_INET;
-        server_address.sin_addr.s_addr=htonl(INADDR_ANY);
-        server_address.sin_port=htons(SERVER_PORT);
-        server_len=sizeof(server_address);
 
-        if(bind(server_sockfd, (struct sockaddr *)&server_address, server_len) < 0) {
-                sprintf(errlog, "[JASM-DAEMON][bind()]Error: %s\n", strerror(errno));
-                log_error("[JASM-DAEMON][bind()]Failed to bind socket");
-                log_error(errlog);
-                log_error("[JASM-DAEMON] Exiting !");
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_ERR,"socket not correctly binded... exiting!");
-                closelog();
-                exit(SOCKET_BINDING_FAILED);
-        }
+        for (fd = 0; fd < FD_SETSIZE; fd++)
+        {
+            if (FD_ISSET (fd, &testfds) )
+            {
+                if (fd == server_sockfd)
+                {
+                    client_len = sizeof (client_address);
+                    client_sockfd = accept (server_sockfd, (struct sockaddr *) &client_address, &client_len);
+                    if (client_sockfd < 0)
+                    {
+                        sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                        log_error ("[JASM-DAEMON][accept()]Failed to accept socket connection!");
+                        log_error (errlog);
+                        openlog ("JASM", LOG_PID, LOG_DAEMON);
+                        syslog (LOG_ERR, "FATAL! Failed to accept client incoming connection! Exiting...");
+                        closelog();
+                        exit (SOCKET_CLIENT_CONNECTION_FAILED);
+                    }
 
-        if(listen(server_sockfd, 5) < 0) {
-                sprintf(errlog, "[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                log_error("[JASM-DAEMON][listen()]Failed to put socket in listening mode!");
-                log_error(errlog);
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_ERR, "FATAL! socket was not put to listening mode! Exiting...");
-                closelog();
-                exit(SOCKET_LISTENING_CONNECTION_FAILED);
-        }
+                    FD_SET (client_sockfd, &readfds);
+                    sprintf (client_ipaddr, "%d.%d.%d.%d", client_address.sin_addr.s_addr & 0xFF, (client_address.sin_addr.s_addr & 0xFF00) >> 8, (client_address.sin_addr.s_addr & 0xFF0000) >> 16, (client_address.sin_addr.s_addr & 0xFF000000) >> 24);
+                    if (login_required (client_ipaddr) == 1)
+                    {
+                        int rpwd;
+                        char getpasswd[256];
+                        const char auth[] = "auth-required";
+                        const char granted[] = "granted";
+                        const char denied[] = "denied";
+                        char passwd_from_client[256];
 
-        FD_ZERO(&readfds);
-        FD_SET(server_sockfd, &readfds);
+                        FILE* source_passwd;
 
-        log_string("[JASM-DAEMON]Server started");
-
-        while(1) {
-                char buf[BUFSIZ];
-                char received[BUFSIZ];
-                int fd;
-                int nread;
-
-                testfds=readfds;
-
-                result=select(FD_SETSIZE, &testfds, (fd_set *)0, (fd_set *)0, (struct timeval *)0);
-
-                if(result<1) {
-                        sprintf(errlog,"[JASM-DAEMON]Error: %s\n",strerror(errno));
-                        log_error("[JASM-DAEMON][select()]Server failed");
-                        log_error(errlog);
-                        exit(SOCKET_SELECT_FAILED);
-                }
-
-                for(fd=0; fd<FD_SETSIZE; fd++) {
-                        if(FD_ISSET(fd, &testfds)) {
-                                if(fd == server_sockfd) {
-                                        client_len = sizeof(client_address);
-                                        client_sockfd = accept(server_sockfd, (struct sockaddr *)&client_address, &client_len);
-                                        if(client_sockfd < 0) {
-                                                sprintf(errlog, "[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                                                log_error("[JASM-DAEMON][accept()]Failed to accept socket connection!");
-                                                log_error(errlog);
-                                                openlog("JASM", LOG_PID,LOG_DAEMON);
-                                                syslog(LOG_ERR, "FATAL! Failed to accept client incoming connection! Exiting...");
-                                                closelog();
-                                                exit(SOCKET_CLIENT_CONNECTION_FAILED);
-                                        }
-
-                                        FD_SET(client_sockfd, &readfds);
-                                        sprintf(client_ipaddr, "%d.%d.%d.%d", client_address.sin_addr.s_addr&0xFF,(client_address.sin_addr.s_addr&0xFF00)>>8, (client_address.sin_addr.s_addr&0xFF0000)>>16, (client_address.sin_addr.s_addr&0xFF000000)>>24);
-                                        if(login_required(client_ipaddr) == 1) {
-                                                int rpwd;
-                                                char getpasswd[256];
-                                                const char auth[]="auth-required";
-                                                const char granted[]="granted";
-                                                const char denied[]="denied";
-                                                char passwd_from_client[256];
-
-                                                FILE* source_passwd;
-
-                                                log_string("[CLIENT-AUTH]Authentication required!");
-                                                if(write(client_sockfd, auth, strlen(auth)) < 0) {
-                                                        sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                        log_error("[write()][auth] Error");
-                                                        log_error(errlog);
-                                                }
-
-                                                if((rpwd = read(client_sockfd, getpasswd, sizeof(getpasswd))) < 0) {
-                                                        sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                                                        log_error("[read()][getpasswd] Error");
-                                                        log_error(errlog);
-                                                }
-
-                                                if(rpwd == 0) {
-                                                        log_string("[JASM-DAEMON]Client disconnected or leaved empty while inserting password");
-                                                        shutdown(client_sockfd, 2);
-                                                        break;
-                                                }
-
-                                                if((source_passwd=fopen(PASSWD_ENC_FILE,"r")) != NULL) {
-                                                        fgets(passwd_from_client,BUFSIZ,source_passwd);
-                                                        fclose(source_passwd);
-                                                } else {
-                                                        log_error("[JASM-DAEMON][FILE]Password file not found!");
-                                                        log_error("[SECURITY]JASM is going to be killed to avoid intrusion");
-                                                        exit(NOFILE_ERROR);
-                                                }
-
-                                                if(strcmp(getpasswd,passwd_from_client) == 0) {
-                                                        log_string("[PWD][OK]Password accepted!");
-                                                        log_string("[PWD][OK]Authorized!");
-                                                        if(write(client_sockfd, granted, strlen(granted)) < 0) {
-                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                log_error("[core/ipc.c][start_server()][getpasswd][write()] ERROR while sending granted");
-                                                                log_error(errlog);
-                                                        }
-                                                } else if(strcmp(getpasswd,passwd_from_client) != 0) {
-
-                                                        log_error("[PWD][DEN]Wrong password!");
-                                                        if(write(client_sockfd, denied, strlen(denied))<0) {
-                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                log_error("[JASM-DAEMON][write()] Error!");
-                                                                log_error(errlog);
-                                                        }
-
-                                                        if(write(client_sockfd,"retry\0",6) < 0) {
-                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                log_error("[JASM-DAEMON][write()] Error");
-                                                                log_error(errlog);
-                                                        }
-
-                                                        for(int i=1; i<=4; i++) {
-                                                                FILE * chkfile;
-                                                                char passwd[256];
-                                                                char attstr[BUFSIZ];
-
-                                                                int nbs = read(client_sockfd,passwd,sizeof(passwd));
-                                                                if(nbs==0) {
-                                                                        log_string("[JASM-DAEMON][LOGIN]0 Bytes received!");
-                                                                        break;
-                                                                } else if(nbs < 0) {
-                                                                        sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                                                                        log_error("[JASM-DAEMON][read()] Error");
-                                                                        log_error(errlog);
-                                                                }
-
-                                                                if(strcmp(passwd, passwd_from_client) == 0) {
-                                                                        if((chkfile=fopen(CHECK_ACCESS_FILE,"w+"))==NULL)
-                                                                        { /*Ciao sono Giuseppe Simone*/}
-                                                                        fprintf(chkfile, "falset");
-                                                                        fclose(chkfile);
-                                                                        sprintf(attstr,"[JASM-DAEMON][LOGIN]Attempt: %d SUCCESS!",i);
-                                                                        log_string(attstr);
-                                                                        if(write(client_sockfd, "authorized", strlen("authorized"))<0) {
-                                                                                sprintf(errlog, "[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                                                                                log_error("[JASM-DAEMON][write()] Error");
-                                                                                log_error(errlog);
-                                                                        }
-                                                                        break;
-                                                                } else if(strcmp(passwd,passwd_from_client) != 0) {
-                                                                        if((chkfile=fopen(CHECK_ACCESS_FILE,"w+"))==NULL)
-                                                                        { /*Ciao sono Rosario Muniz, moroso di Stefano Belli :D*/}
-                                                                        fprintf(chkfile,"true");
-                                                                        fclose(chkfile);
-                                                                        sprintf(attstr,"[JASM-DAEMON][LOGIN]Attempt: %d FAILED!",i);
-                                                                        log_string(attstr);
-
-                                                                        if(write(client_sockfd, "retry", strlen("retry"))<0) {
-                                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                                log_error("[JASM-DAEMON][write()] Error");
-                                                                                log_error(errlog);
-                                                                        }
-
-                                                                        if(i==3) {
-                                                                                shutdown(client_sockfd,2);
-                                                                                log_string("[JASM-DAEMON][ALERT]Connection with client was shutted down!");
-                                                                                log_string("[JASM-DAEMON][ALERT]More than 3 tries failed!");
-                                                                                break;
-                                                                        }
-                                                                }
-                                                        }
-                                                }
-                                        } else {
-                                                const char chkpwd[]="check-pwd-file";
-                                                const char nochkpwd[]="nochk-pwdfile";
-                                                int chkfile;
-                                                const char not_required[]="auth-not-required";
-
-                                                if(write(client_sockfd, not_required, strlen(not_required)) < 0)
-                                                        log_error("[not_required][write()] Error");
-                                                log_string("[CLIENT-AUTH]Authentication NOT required!");
-                                                chkfile = check_passwd_file(PASSWD_ENC_FILE);
-
-                                                if(chkfile == 0) {
-                                                        if(write(client_sockfd, nochkpwd, strlen(nochkpwd)) < 0) {
-                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                log_error("[chkfile][write()] error");
-                                                                log_error(errlog);
-                                                        }
-                                                } else if(chkfile == 1) {
-                                                        FILE *pswfp;
-                                                        char buf_in_passwd[256];
-
-                                                        if(write(client_sockfd, chkpwd, strlen(chkpwd)) < 0) {
-                                                                sprintf(errlog, "[JASM-DAEMON][errno] Errno: %s", strerror(errno));
-                                                                log_error("[chkfile][write()] error");
-                                                                log_error(errlog);
-                                                        }
-
-                                                        if(read(client_sockfd, buf_in_passwd, sizeof(buf_in_passwd)) < 0) {
-                                                                sprintf(errlog,"[JASM-DAEMON][errno] Errno: %s",strerror(errno));
-                                                                log_error("[chkfile][read()] error");
-                                                                log_error(errlog);
-                                                        }
-
-                                                        //log_string(buf_in_passwd);
-                                                        if((pswfp=fopen(PASSWD_ENC_FILE,"w+")) != NULL) {
-                                                                fputs(buf_in_passwd,pswfp);
-                                                                fclose(pswfp);
-                                                        }
-                                                }
-                                        }
-
-                                        sprintf(buf, "[CLIENT-CONNECT] sockfd: %d, IP Address: %s", client_sockfd, client_ipaddr);
-
-                                        //Using the client struct
-                                        log_string(buf);
-                                } else {
-                                        ioctl(fd, FIONREAD, &nread);
-
-                                        if(nread==0) {
-                                                close(fd);
-                                                FD_CLR(fd, &readfds);
-                                                sprintf(buf, "[CLIENT-DISCONNECT] sockfd: %d, IP Address: %s", client_sockfd, client_ipaddr);
-                                                //Using the client struct
-                                                log_string(buf);
-                                        } else {
-                                                memset(received, 0, sizeof(received));
-                                                read(fd, received, sizeof(received));
-                                                sprintf(buf, "[CMD-GET] Got command from %d: <%s>", fd, received);
-                                                log_string(buf);
-                                                excecute_command(fd, received);
-                                        }
-                                }
+                        log_string ("[CLIENT-AUTH]Authentication required!");
+                        if (write (client_sockfd, auth, strlen (auth) ) < 0)
+                        {
+                            sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                            log_error ("[write()][auth] Error");
+                            log_error (errlog);
                         }
+
+                        if ( (rpwd = read (client_sockfd, getpasswd, sizeof (getpasswd) ) ) < 0)
+                        {
+                            sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                            log_error ("[read()][getpasswd] Error");
+                            log_error (errlog);
+                        }
+
+                        if (rpwd == 0)
+                        {
+                            log_string ("[JASM-DAEMON]Client disconnected or leaved empty while inserting password");
+                            shutdown (client_sockfd, 2);
+                            break;
+                        }
+
+                        if ( (source_passwd = fopen (PASSWD_ENC_FILE, "r") ) != NULL)
+                        {
+                            fgets (passwd_from_client, BUFSIZ, source_passwd);
+                            fclose (source_passwd);
+                        }
+                        else
+                        {
+                            log_error ("[JASM-DAEMON][FILE]Password file not found!");
+                            log_error ("[SECURITY]JASM is going to be killed to avoid intrusion");
+                            exit (NOFILE_ERROR);
+                        }
+
+                        if (strcmp (getpasswd, passwd_from_client) == 0)
+                        {
+                            log_string ("[PWD][OK]Password accepted!");
+                            log_string ("[PWD][OK]Authorized!");
+                            if (write (client_sockfd, granted, strlen (granted) ) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[core/ipc.c][start_server()][getpasswd][write()] ERROR while sending granted");
+                                log_error (errlog);
+                            }
+                        }
+                        else if (strcmp (getpasswd, passwd_from_client) != 0)
+                        {
+
+                            log_error ("[PWD][DEN]Wrong password!");
+                            if (write (client_sockfd, denied, strlen (denied) ) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[JASM-DAEMON][write()] Error!");
+                                log_error (errlog);
+                            }
+
+                            if (write (client_sockfd, "retry\0", 6) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[JASM-DAEMON][write()] Error");
+                                log_error (errlog);
+                            }
+
+                            for (int i = 1; i <= 4; i++)
+                            {
+                                FILE * chkfile;
+                                char passwd[256];
+                                char attstr[BUFSIZ];
+
+                                int nbs = read (client_sockfd, passwd, sizeof (passwd) );
+                                if (nbs == 0)
+                                {
+                                    log_string ("[JASM-DAEMON][LOGIN]0 Bytes received!");
+                                    break;
+                                }
+                                else if (nbs < 0)
+                                {
+                                    sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                    log_error ("[JASM-DAEMON][read()] Error");
+                                    log_error (errlog);
+                                }
+
+                                if (strcmp (passwd, passwd_from_client) == 0)
+                                {
+                                    if ( (chkfile = fopen (CHECK_ACCESS_FILE, "w+") ) == NULL)
+                                    {
+                                        /*Ciao sono Giuseppe Simone*/
+                                    }
+                                    fprintf (chkfile, "falset");
+                                    fclose (chkfile);
+                                    sprintf (attstr, "[JASM-DAEMON][LOGIN]Attempt: %d SUCCESS!", i);
+                                    log_string (attstr);
+                                    if (write (client_sockfd, "authorized", strlen ("authorized") ) < 0)
+                                    {
+                                        sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                        log_error ("[JASM-DAEMON][write()] Error");
+                                        log_error (errlog);
+                                    }
+                                    break;
+                                }
+                                else if (strcmp (passwd, passwd_from_client) != 0)
+                                {
+                                    if ( (chkfile = fopen (CHECK_ACCESS_FILE, "w+") ) == NULL)
+                                    {
+                                        /*Ciao sono Rosario Muniz, moroso di Stefano Belli :D*/
+                                    }
+                                    fprintf (chkfile, "true");
+                                    fclose (chkfile);
+                                    sprintf (attstr, "[JASM-DAEMON][LOGIN]Attempt: %d FAILED!", i);
+                                    log_string (attstr);
+
+                                    if (write (client_sockfd, "retry", strlen ("retry") ) < 0)
+                                    {
+                                        sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                        log_error ("[JASM-DAEMON][write()] Error");
+                                        log_error (errlog);
+                                    }
+
+                                    if (i == 3)
+                                    {
+                                        shutdown (client_sockfd, 2);
+                                        log_string ("[JASM-DAEMON][ALERT]Connection with client was shutted down!");
+                                        log_string ("[JASM-DAEMON][ALERT]More than 3 tries failed!");
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    else
+                    {
+                        const char chkpwd[] = "check-pwd-file";
+                        const char nochkpwd[] = "nochk-pwdfile";
+                        int chkfile;
+                        const char not_required[] = "auth-not-required";
+
+                        if (write (client_sockfd, not_required, strlen (not_required) ) < 0)
+                            log_error ("[not_required][write()] Error");
+                        log_string ("[CLIENT-AUTH]Authentication NOT required!");
+                        chkfile = check_passwd_file (PASSWD_ENC_FILE);
+
+                        if (chkfile == 0)
+                        {
+                            if (write (client_sockfd, nochkpwd, strlen (nochkpwd) ) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[chkfile][write()] error");
+                                log_error (errlog);
+                            }
+                        }
+                        else if (chkfile == 1)
+                        {
+                            FILE *pswfp;
+                            char buf_in_passwd[256];
+
+                            if (write (client_sockfd, chkpwd, strlen (chkpwd) ) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[chkfile][write()] error");
+                                log_error (errlog);
+                            }
+
+                            if (read (client_sockfd, buf_in_passwd, sizeof (buf_in_passwd) ) < 0)
+                            {
+                                sprintf (errlog, "[JASM-DAEMON][errno] Errno: %s", strerror (errno) );
+                                log_error ("[chkfile][read()] error");
+                                log_error (errlog);
+                            }
+
+                            //log_string(buf_in_passwd);
+                            if ( (pswfp = fopen (PASSWD_ENC_FILE, "w+") ) != NULL)
+                            {
+                                fputs (buf_in_passwd, pswfp);
+                                fclose (pswfp);
+                            }
+                        }
+                    }
+
+                    sprintf (buf, "[CLIENT-CONNECT] sockfd: %d, IP Address: %s", client_sockfd, client_ipaddr);
+
+                    //Using the client struct
+                    log_string (buf);
                 }
+                else
+                {
+                    ioctl (fd, FIONREAD, &nread);
+
+                    if (nread == 0)
+                    {
+                        close (fd);
+                        FD_CLR (fd, &readfds);
+                        sprintf (buf, "[CLIENT-DISCONNECT] sockfd: %d, IP Address: %s", client_sockfd, client_ipaddr);
+                        //Using the client struct
+                        log_string (buf);
+                    }
+                    else
+                    {
+                        memset (received, 0, sizeof (received) );
+                        read (fd, received, sizeof (received) );
+                        sprintf (buf, "[CMD-GET] Got command from %d: <%s>", fd, received);
+                        log_string (buf);
+                        excecute_command (fd, received);
+                    }
+                }
+            }
         }
+    }
 }

--- a/src/main/jasm/core/ipc.h
+++ b/src/main/jasm/core/ipc.h
@@ -22,6 +22,6 @@
 #define SERVER_PORT 9734
 #define SERVER_IP "127.0.0.1"
 
-extern void start_server(void);
+extern void start_server (void);
 
 #endif

--- a/src/main/jasm/core/jasm.c
+++ b/src/main/jasm/core/jasm.c
@@ -24,23 +24,25 @@
 #include "signals.h"
 #include "configfile.h"
 
-int main(int argc, char *argv[])
+int main (int argc, char *argv[])
 {
-        start_daemon(); //starts background daemon
-        set_signals_feel(); //logs a set of signals
+    start_daemon(); //starts background daemon
+    set_signals_feel(); //logs a set of signals
 
-        if(set_property_value()==1) {
-                log_string("[JASM-DAEMON][INFO]You need to create a configuration file");
-                log_string("[JASM-DAEMON][INFO]Using standard values");
-                log_string("[JASM-DAEMON][INFO]Server's config source: $HOME/.jasm_config");
-        } else
-                log_string("[JASM-DAEMON][INFO]Using values defined in the server's configuration file!");
+    if (set_property_value() == 1)
+    {
+        log_string ("[JASM-DAEMON][INFO]You need to create a configuration file");
+        log_string ("[JASM-DAEMON][INFO]Using standard values");
+        log_string ("[JASM-DAEMON][INFO]Server's config source: $HOME/.jasm_config");
+    }
+    else
+        log_string ("[JASM-DAEMON][INFO]Using values defined in the server's configuration file!");
 
-        #ifdef DEBUG
-        char logval[BUFSIZ];
-        sprintf(logval,"[JASM-DAEMON][DEBUG][EXTERNAL-CHECK]Reading value: %d ,%d",*(int*)_config[0].config_values,*(int*)_config[1].config_values);
-        log_string(logval);
-        #endif
+#ifdef DEBUG
+    char logval[BUFSIZ];
+    sprintf (logval, "[JASM-DAEMON][DEBUG][EXTERNAL-CHECK]Reading value: %d ,%d", * (int*) _config[0].config_values, * (int*) _config[1].config_values);
+    log_string (logval);
+#endif
 
-        start_server(); //starts server after the daemon (ready to get commands)
+    start_server(); //starts server after the daemon (ready to get commands)
 }

--- a/src/main/jasm/core/miscellaneous.c
+++ b/src/main/jasm/core/miscellaneous.c
@@ -32,126 +32,134 @@
 
 char errlog[BUFSIZ]; // pattern to follow: [SECTION][ERROR]Errno: %s ...
 
-char buildate[256]="null";
+char buildate[256] = "null";
 
 char *getTime()
 {
-        time_t curtime;
-        struct tm *loctime;
-        static char *ret;
+    time_t curtime;
+    struct tm *loctime;
+    static char *ret;
 
-        curtime=time(NULL);
-        loctime=localtime(&curtime);
-        ret=asctime(loctime);
-        ret[24]='\0';
+    curtime = time (NULL);
+    loctime = localtime (&curtime);
+    ret = asctime (loctime);
+    ret[24] = '\0';
 
-        return ret;
+    return ret;
 }
 
 void check_buildate()
 {
-  #ifdef BUILD_DATE_CORE
-        strcpy(buildate,BUILD_DATE_CORE);
-  #else
-        strcpy(buildate,"not availible");
-  #endif
+#ifdef BUILD_DATE_CORE
+    strcpy (buildate, BUILD_DATE_CORE);
+#else
+    strcpy (buildate, "not availible");
+#endif
 }
 
-void log_string(const char *message)
+void log_string (const char *message)
 {
-        FILE *fp;
+    FILE *fp;
 
-        if((fp=fopen(LOGPATH, "a+")) == NULL) {
-                fprintf(fp,"[%s][INFO]This file is created now.",getTime());
-        } else {
-                fprintf(fp, "[%s][INFO] %s\n", getTime(), message);
-                fclose(fp);
-        }
+    if ( (fp = fopen (LOGPATH, "a+") ) == NULL)
+    {
+        fprintf (fp, "[%s][INFO]This file is created now.", getTime() );
+    }
+    else
+    {
+        fprintf (fp, "[%s][INFO] %s\n", getTime(), message);
+        fclose (fp);
+    }
 }
 
-void log_error(const char *message)
+void log_error (const char *message)
 {
-        FILE *fp;
+    FILE *fp;
 
-        if((fp=fopen(LOGPATH, "a+")) == NULL) {
-                fprintf(fp,"[%s][INFO] This file is created now.",getTime());
-        } else {
-                fprintf(fp, "[%s][ERROR] %s!\n", getTime(), message);
-                fclose(fp);
-        }
+    if ( (fp = fopen (LOGPATH, "a+") ) == NULL)
+    {
+        fprintf (fp, "[%s][INFO] This file is created now.", getTime() );
+    }
+    else
+    {
+        fprintf (fp, "[%s][ERROR] %s!\n", getTime(), message);
+        fclose (fp);
+    }
 }
 
 void start_daemon()
 {
-        check_buildate();
+    check_buildate();
 
-        pid_t pid;
-        char buf[BUFSIZ];
-        char buf_intro[BUFSIZ];
+    pid_t pid;
+    char buf[BUFSIZ];
+    char buf_intro[BUFSIZ];
 
-        sprintf(buf_intro,"[START]JASM System Monitor Starting Up... Version: %s , Build Date: %s",VERSION,buildate);
+    sprintf (buf_intro, "[START]JASM System Monitor Starting Up... Version: %s , Build Date: %s", VERSION, buildate);
 
-        log_string("=======================================");
-        #ifdef DEBUG
-        log_string("[BUILD] You are using JASM debug build!");
-        #endif
+    log_string ("=======================================");
+#ifdef DEBUG
+    log_string ("[BUILD] You are using JASM debug build!");
+#endif
 
-        log_string(buf_intro);
-        log_string("[JASM-DAEMON] Creating new process...");
-        pid=fork();
-        switch(pid) {
-        case -1:
-                sprintf(errlog,"[PROCESS-SPAWN]Error: %s\n",strerror(errno));
-                log_error("[PROCESS-SPAWN][fork()] failed");
-                log_error(errlog);
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_ERR,"Process spawning failed!");
-                closelog();
-                exit(ERR_SET_PROCESS_SPAWN);
-                break;
-
-        case 0:
-                log_string("[PROCESS-SPAWN][fork()] success");
-                break;
-
-        default:
-                exit(_EXIT_SUCCESS);
-                break;
-        }
-        if(setsid()<0) {
-                log_error("[PROCESS-BACKGROUND][setsid()] failed");
-                sprintf(errlog,"[PROCESS-BACKGROUND]Error: %s\n",strerror(errno));
-                log_error(errlog);
-                openlog("JASM",LOG_PID,LOG_DAEMON);
-                syslog(LOG_ERR,"Put process background failed!");
-                closelog();
-                exit(ERR_SET_PROCESS_BACKGROUND);
-        }
-        else   log_string("[PROCESS-BACKGROUND][setsid()] success");
-
-        //closes fd: stdin, stdout, stderr
-        close(0);
-        close(1);
-        close(2);
-
-        sprintf(buf, "[JASM-DAEMON][START] PID: %d , Parent PID: %d", getpid(), getppid());
-        log_string(buf);
-        log_string("[JASM-DAEMON][START] Start phase successfully completed!");
-        log_string("[JASM-DAEMON][STATUS] Ready!");
-        openlog("JASM",LOG_PID,LOG_DAEMON);
-        syslog(LOG_INFO,"SUCCESS! New jasm process created! READY!");
+    log_string (buf_intro);
+    log_string ("[JASM-DAEMON] Creating new process...");
+    pid = fork();
+    switch (pid)
+    {
+    case -1:
+        sprintf (errlog, "[PROCESS-SPAWN]Error: %s\n", strerror (errno) );
+        log_error ("[PROCESS-SPAWN][fork()] failed");
+        log_error (errlog);
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_ERR, "Process spawning failed!");
         closelog();
+        exit (ERR_SET_PROCESS_SPAWN);
+        break;
+
+    case 0:
+        log_string ("[PROCESS-SPAWN][fork()] success");
+        break;
+
+    default:
+        exit (_EXIT_SUCCESS);
+        break;
+    }
+    if (setsid() < 0)
+    {
+        log_error ("[PROCESS-BACKGROUND][setsid()] failed");
+        sprintf (errlog, "[PROCESS-BACKGROUND]Error: %s\n", strerror (errno) );
+        log_error (errlog);
+        openlog ("JASM", LOG_PID, LOG_DAEMON);
+        syslog (LOG_ERR, "Put process background failed!");
+        closelog();
+        exit (ERR_SET_PROCESS_BACKGROUND);
+    }
+    else   log_string ("[PROCESS-BACKGROUND][setsid()] success");
+
+    //closes fd: stdin, stdout, stderr
+    close (0);
+    close (1);
+    close (2);
+
+    sprintf (buf, "[JASM-DAEMON][START] PID: %d , Parent PID: %d", getpid(), getppid() );
+    log_string (buf);
+    log_string ("[JASM-DAEMON][START] Start phase successfully completed!");
+    log_string ("[JASM-DAEMON][STATUS] Ready!");
+    openlog ("JASM", LOG_PID, LOG_DAEMON);
+    syslog (LOG_INFO, "SUCCESS! New jasm process created! READY!");
+    closelog();
 }
 
 /*LOGIN SECTION*/
-int login_required(const char* clientaddr)
+int login_required (const char* clientaddr)
 {
-        if(strcmp(clientaddr,LOCALHOST) == 0) return 0;
-        else return 1;
+    if (strcmp (clientaddr, LOCALHOST) == 0) return 0;
+    else return 1;
 }
 
-int check_passwd_file(const char* __pwdf)
+int check_passwd_file (const char* __pwdf)
 {
-        if(access(__pwdf,F_OK) != -1) return 0;
-        else return 1;
+    if (access (__pwdf, F_OK) != -1) return 0;
+    else return 1;
 }

--- a/src/main/jasm/core/miscellaneous.h
+++ b/src/main/jasm/core/miscellaneous.h
@@ -36,11 +36,11 @@
 
 extern char buildate[256];
 
-extern char *getTime(void);
-extern void log_string(const char *message);
-extern void log_error(const char *message);
-extern void start_daemon(void);
-extern int login_required(const char *clientaddr);
-extern int check_passwd_file(const char* __pwdf);
+extern char *getTime (void);
+extern void log_string (const char *message);
+extern void log_error (const char *message);
+extern void start_daemon (void);
+extern int login_required (const char *clientaddr);
+extern int check_passwd_file (const char* __pwdf);
 
 #endif

--- a/src/main/jasm/core/modules.c
+++ b/src/main/jasm/core/modules.c
@@ -25,22 +25,23 @@
 #include "../modules/module_logsender.h"
 
 char moduleName[NMODULE][BUFSIZ] = {"Logsender"};
-void (*moduleInit[NMODULE])(int, int) = {init_logsender};
-void (*moduleStart[NMODULE])(void) = {start_logsender};
+void (*moduleInit[NMODULE]) (int, int) = {init_logsender};
+void (*moduleStart[NMODULE]) (void) = {start_logsender};
 
-void getModule(int fd)
+void getModule (int fd)
 {
-        int count=0;
-        int nmodule = NMODULE;
+    int count = 0;
+    int nmodule = NMODULE;
 
-        write(fd, &nmodule, sizeof(nmodule));
+    write (fd, &nmodule, sizeof (nmodule) );
 
-        for(int i=0; i<NMODULE; i++) {
-                count = strlen(moduleName[i]);
+    for (int i = 0; i < NMODULE; i++)
+    {
+        count = strlen (moduleName[i]);
 
-                //aggiungere check errore nell'invio
-                write(fd, &count, sizeof(count));
-                write(fd, moduleName[i], strlen(moduleName[i]));
-        }
+        //aggiungere check errore nell'invio
+        write (fd, &count, sizeof (count) );
+        write (fd, moduleName[i], strlen (moduleName[i]) );
+    }
 
 }

--- a/src/main/jasm/core/modules.h
+++ b/src/main/jasm/core/modules.h
@@ -21,18 +21,19 @@
 
 #define NMODULE 1
 
-struct module_running {
-        pthread_t tid;
-        char name[BUFSIZ];
+struct module_running
+{
+    pthread_t tid;
+    char name[BUFSIZ];
 };
 
 //this array cointains modules in execution on threads
 extern struct module_running module_table[NMODULE];
 
 extern char moduleName[NMODULE][BUFSIZ];
-extern void (*moduleInit[NMODULE])(int, int);
-extern void (*moduleStart[NMODULE])(void);
+extern void (*moduleInit[NMODULE]) (int, int);
+extern void (*moduleStart[NMODULE]) (void);
 
-extern void getModule(int fd);
+extern void getModule (int fd);
 
 #endif

--- a/src/main/jasm/core/signals.c
+++ b/src/main/jasm/core/signals.c
@@ -25,22 +25,22 @@
 #include "miscellaneous.h"
 #include "signals.h"
 
-static void generic_signal_log(int sig)
+static void generic_signal_log (int sig)
 {
-								char buf[BUFSIZ];
+    char buf[BUFSIZ];
 
-								sprintf(buf, "Received signal number %d", sig);
-								log_string(buf);
+    sprintf (buf, "Received signal number %d", sig);
+    log_string (buf);
 }
 
 void set_signals_feel()
 {
-								struct sigaction act;
+    struct sigaction act;
 
-								act.sa_handler=generic_signal_log;
-								act.sa_flags=0;
-								sigaction(SIGINT, &act, 0);
-								sigaction(SIGQUIT, &act, 0);
-								sigaction(SIGCONT, &act, 0);
-								sigaction(SIGSTOP, &act, 0);
+    act.sa_handler = generic_signal_log;
+    act.sa_flags = 0;
+    sigaction (SIGINT, &act, 0);
+    sigaction (SIGQUIT, &act, 0);
+    sigaction (SIGCONT, &act, 0);
+    sigaction (SIGSTOP, &act, 0);
 }

--- a/src/main/jasm/core/signals.h
+++ b/src/main/jasm/core/signals.h
@@ -19,6 +19,6 @@
 #ifndef _SIGNALS_H
 #define _SIGNALS_H
 
-extern void set_signals_feel(void);
+extern void set_signals_feel (void);
 
 #endif


### PR DESCRIPTION
Format all files using the astyle external utilty with the following
parameters; astyle --indent=spaces=4 --style=allman --pad-oper
--pad-paren-out

[Per i dev italiani] Ho uniformato lo stile del codice, introducendo una base 'pulita artisticamente' su cui lavorare. Ho messo l'indentazione a 4 spazi, non tab, perchè quasi tutti usano 4 spazi ed è meglio di 8 che spreca molto spazio. Ho aggiunto uno spazio intorno agli operatori e intorno alle parentesi
